### PR TITLE
Raise TYPO3 version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.4,<8.2",
-		"typo3/cms-core": ">=10.4.0,<=11.5.99"
+		"typo3/cms-core": ">=10.4.0,<=12.4.99"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Everything appears to run normally with TYPO3 12, only the composer dependency needs to be adjusted.