### PR TITLE
[TASK] Regex filter for folder- and filenames

### DIFF
--- a/Classes/Task/DeleteFilesAdditionalFieldProvider.php
+++ b/Classes/Task/DeleteFilesAdditionalFieldProvider.php
@@ -62,6 +62,16 @@ class DeleteFilesAdditionalFieldProvider extends AbstractAdditionalFieldProvider
             }
         }
 
+        if (empty($taskInfo['deletefiles_regex'])) {
+            if ($action === 'add') {
+                $taskInfo['deletefiles_regex'] = '';
+            } elseif ($action === 'edit') {
+                $taskInfo['deletefiles_regex'] = $task->deletefiles_regex;
+            } else {
+                $taskInfo['deletefiles_regex'] = '';
+            }
+        }
+
         if (empty($taskInfo['deletefiles_time'])) {
             if ($action === 'add') {
                 $taskInfo['deletefiles_time'] = [];
@@ -93,6 +103,19 @@ class DeleteFilesAdditionalFieldProvider extends AbstractAdditionalFieldProvider
             'label' => $this->translate('addfields_label_directory'),
             'cshKey' => 'deletefiles',
             'cshLabel' => 'addfields_label_directory',
+        ];
+
+        // Render regex field
+        $fieldId = 'task_deletefiles_regex';
+        $fieldCode = '<input type="text" name="tx_scheduler[deletefiles_regex]" id="'.$fieldId.'" value="'.
+            htmlspecialchars($taskInfo['deletefiles_regex']).'" class="" width="120">';
+
+        $additionalFields[$fieldId] = [
+            'type' => 'input',
+            'code' => $fieldCode,
+            'label' => $this->translate('addfields_label_regex'),
+            'cshKey' => 'deletefiles',
+            'cshLabel' => 'addfields_label_regex',
         ];
 
         // Render time field
@@ -205,7 +228,18 @@ class DeleteFilesAdditionalFieldProvider extends AbstractAdditionalFieldProvider
             );
             $validInput = false;
         }
-
+        $regex = trim($submittedData['deletefiles_regex']);
+        if (!empty($regex)) {
+            @preg_match($regex, '');
+            $error = preg_last_error();
+            if ($error !== PREG_NO_ERROR) {
+                $this->addMessage(
+                    sprintf($this->translate('addfields_notice_regex_invalid'), $regex),
+                    AbstractMessage::ERROR
+                );
+                $validInput = false;
+            }
+        }
         return $validInput;
     }
 
@@ -215,6 +249,7 @@ class DeleteFilesAdditionalFieldProvider extends AbstractAdditionalFieldProvider
     public function saveAdditionalFields(array $submittedData, AbstractTask $task)
     {
         $task->deletefiles_directory = $submittedData['deletefiles_directory'];
+        $task->deletefiles_regex = trim($submittedData['deletefiles_regex']);
         $task->deletefiles_time = $submittedData['deletefiles_time'];
         $task->deletefiles_method = $submittedData['deletefiles_method'];
     }

--- a/Classes/Task/DeleteFilesAdditionalFieldProvider.php
+++ b/Classes/Task/DeleteFilesAdditionalFieldProvider.php
@@ -90,7 +90,7 @@ class DeleteFilesAdditionalFieldProvider extends AbstractAdditionalFieldProvider
         $additionalFields[$fieldId] = [
             'type' => 'input',
             'code' => $fieldCode,
-            'label' => $this->translate('addfields_label_directory').' TEST',
+            'label' => $this->translate('addfields_label_directory'),
             'cshKey' => 'deletefiles',
             'cshLabel' => 'addfields_label_directory',
         ];

--- a/Classes/Task/DeleteFilesTask.php
+++ b/Classes/Task/DeleteFilesTask.php
@@ -23,6 +23,8 @@ class DeleteFilesTask extends AbstractTask
 
     public ?string $deletefiles_directory = null;
 
+    public ?string $deletefiles_regex = null;
+
     public ?string $deletefiles_time = null;
 
     public ?string $deletefiles_method = null;
@@ -146,6 +148,7 @@ class DeleteFilesTask extends AbstractTask
         $text = '';
 
         $text .= $this->deletefiles_directory;
+        $text .= $this->deletefiles_regex;
         $text .= ', '.$this->deletefiles_method;
         $text .= ', '.$this->deletefiles_time;
 
@@ -158,10 +161,12 @@ class DeleteFilesTask extends AbstractTask
     {
         $this->deletefiles_time = strip_tags($this->deletefiles_time);
         $this->deletefiles_directory = strip_tags($this->deletefiles_directory);
+        $this->deletefiles_regex = strip_tags($this->deletefiles_regex);
         $this->deletefiles_method = strip_tags($this->deletefiles_method);
 
         $this->log('$this->time: '.$this->deletefiles_time);
         $this->log('$this->extkey: '.$this->deletefiles_directory);
+        $this->log('$this->regex: '.$this->deletefiles_regex);
         $this->log('$this->method: '.$this->deletefiles_method);
     }
 
@@ -174,12 +179,15 @@ class DeleteFilesTask extends AbstractTask
     {
         // @todo: better delete error handling
         $flag = true;
-
+        $pattern = $this->deletefiles_regex;
         foreach ($items as $item) {
+            $basename = basename($item);
+            if (!empty($pattern) && !empty($basename) && !preg_match($pattern, $basename)) {
+                continue;
+            }
             if ($this->debugging) {
                 $this->log('Use delete method ['.$this->deletefiles_method.'] on '.$item);
-
-                return true;
+                continue;
             }
 
             switch ($this->deletefiles_method) {

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -14,16 +14,21 @@ Administration
 Just add a new scheduler task via scheduler module.
 You need to define the default values and the deletefiles specific ones:
 
-**Path**  
+**Path**
 
 Define the path to clean. No ending slash. Please double check if its correct.
 
-**Minimum age** 
+**Regular expression for file and folder name**
+
+Define a regex filter for the file or folder name to be cleaned.
+Example: "/^form_/" will clean folders or files that start with "form_"
+
+**Minimum age**
 
 The minimum age of a file or a directory to be deleted by this extension. Checks for the last
 modified timestamp.
 
-**Delete Method** 
+**Delete Method**
 
 What to delete and how to check which files to delete. Please see “Delete Methods” section
 below.

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -6,6 +6,9 @@
 			<trans-unit id="addfields_label_directory">
 				<target>Pfad:</target>
 			</trans-unit>
+			<trans-unit id="addfields_label_regex">
+				<target>Regulärer Ausdruck für Datei- und Ordnernamen:</target>
+			</trans-unit>
 			<trans-unit id="addfields_label_method">
 				<target>Was soll im angegebenen Pfad gelöscht werden?</target>
 			</trans-unit>
@@ -29,6 +32,9 @@
 			</trans-unit>
 			<trans-unit id="addfields_notice_path_invalid">
 				<target>Pfad ungültig: bitte kontrolliere den Pfad!</target>
+			</trans-unit>
+			<trans-unit id="addfields_notice_regex_invalid">
+				<target>Regulärer Ausdruck ungültig: bitte kontrolliere den Regulären Ausdruck!</target>
 			</trans-unit>
 			<trans-unit id="addfields_time_all">
 				<target>Keine Begrenzung</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -6,6 +6,9 @@
 			<trans-unit id="addfields_label_directory">
 				<source>Path:</source>
 			</trans-unit>
+			<trans-unit id="addfields_label_regex">
+				<source>Regular expression for file and folder name:</source>
+			</trans-unit>
 			<trans-unit id="addfields_label_method">
 				<source>What to delete?</source>
 			</trans-unit>
@@ -29,6 +32,9 @@
 			</trans-unit>
 			<trans-unit id="addfields_notice_path_invalid">
 				<source>Path invalid: please check the path again!</source>
+			</trans-unit>
+			<trans-unit id="addfields_notice_regex_invalid">
+				<source>Regex invalid: please check the regex again!</source>
 			</trans-unit>
 			<trans-unit id="addfields_time_all">
 				<source>No limitation</source>


### PR DESCRIPTION
Add new field to the scheduler task called "Regular expression for folder and file names"
This allows you to only delete files or folders that match the regex.
Only the basename of the deletable item will be matched.

Example:
Path: fileadmin/user_upload
Regex: /^folder_/

Matches:
fileadmin/user_upload/folder_12345
but not fileadmin/user_upload/otherfolder_12345
