### PR TITLE
[TASK] Exclude dev-only files from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+/.github export-ignore
+/.gitattributes export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/rector.php export-ignore


### PR DESCRIPTION
Adds a `.gitattributes` file to define several paths as `export-ignore`, effectively excluding them from dist archives. This is especially useful when installing the extension via Composer in order to avoid shipping said files to production environments.